### PR TITLE
Fix latest commanded_eventstore_adapter version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The package can be installed from hex as follows.
 
     ```elixir
     def deps do
-      [{:commanded_eventstore_adapter, "~> 0.3"}]
+      [{:commanded_eventstore_adapter, "~> 0.4"}]
     end
     ```
 


### PR DESCRIPTION
Newcomers might be surprised that version mentioned in README is not compatible with latest commanded ;)
`0.3` breaks with commanded `0.17` with runtime exception:
```
** (UndefinedFunctionError) function Commanded.EventStore.Adapters.EventStore.subscribe/1 is undefined or private
    (commanded_eventstore_adapter) Commanded.EventStore.Adapters.EventStore.subscribe("1")
    (commanded) lib/commanded/registration/registration.ex:149: Commanded.Aggregates.Aggregate.handle_cast/2
    (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: {:"$gen_cast", :subscribe_to_events}
```