### PR TITLE
Update Getting Started.md

### DIFF
--- a/guides/Getting Started.md
+++ b/guides/Getting Started.md
@@ -36,6 +36,8 @@ The package can be installed from hex as follows.
 4. Configure the event store in each environment's mix config file (e.g. `config/dev.exs`), specifying usage of Commanded's JSON serializer:
 
     ```elixir
+    import Config
+    
     config :my_app, MyApp.EventStore,
       serializer: Commanded.Serialization.JsonSerializer,
       username: "postgres",
@@ -49,7 +51,11 @@ The package can be installed from hex as follows.
 
     ```elixir
     # config/config.exs
+    import Config
+
     config :my_app, event_stores: [MyApp.EventStore]
+
+    import_config "#{config_env()}.exs"
     ```
 
 6. Create the EventStore database and tables using the `mix` task:


### PR DESCRIPTION
Added import config.  

Fixes this error:
```
[1]> mix event_store.create
** (KeyError) key :database not found in: [enable_hard_deletes: false, column_data_type: "bytea", schema: "public", pool: DBConnection.ConnectionPool, otp_app: :wallet]
    (elixir 1.13.4) lib/keyword.ex:559: Keyword.fetch!/2
    (eventstore 1.4.0) lib/event_store/storage/database.ex:88: EventStore.Storage.Database.storage_up/1
    (eventstore 1.4.0) lib/event_store/tasks/create.ex:27: EventStore.Tasks.Create.exec/2
    (elixir 1.13.4) lib/enum.ex:937: Enum."-each/2-lists^foreach/1-0-"/2
    (eventstore 1.4.0) lib/mix/tasks/event_store.create.ex:45: Mix.Tasks.EventStore.Create.run/1
    (mix 1.13.4) lib/mix/task.ex:397: anonymous fn/3 in Mix.Task.run_task/3
    (mix 1.13.4) lib/mix/cli.ex:84: Mix.CLI.run_task/2
```