### PR TITLE
Update Dynamic Event Store.md

### DIFF
--- a/guides/Dynamic Event Store.md
+++ b/guides/Dynamic Event Store.md
@@ -24,7 +24,7 @@ defmodule MyApp.Application do
     config = put_in(config, [:event_store, :name], Module.concat([name, EventStore])
 
     # Set event store prefix (Postgres schema)
-    config = put_in(config, [:event_store, :prefix], Atom.to_string(tenant))
+    config = put_in(config, [:event_store, :schema], Atom.to_string(tenant))
 
     {:ok, config}
   end


### PR DESCRIPTION
It seems that `prefix` is being renamed to `schema` anyways, it seems that `prefix` is getting deprecated?

```elixir
    # Rename `prefix` config to `schema`
    config =
      case Keyword.pop(config, :prefix) do
        {nil, config} -> config
        {prefix, config} -> Keyword.put(config, :schema, prefix)
      end
```